### PR TITLE
消除"选中文→强拉 clashoo"的副作用

### DIFF
--- a/luci-app-clashoo/Makefile
+++ b/luci-app-clashoo/Makefile
@@ -75,7 +75,7 @@ define Package/luci-i18n-clashoo-zh-cn
 	SECTION:=luci
 	CATEGORY:=LuCI
 	TITLE:=luci-app-clashoo - Simplified Chinese (zh-cn)
-	DEPENDS:=+luci-app-clashoo
+	DEPENDS:=luci-app-clashoo
 	DEFAULT:=LUCI_LANG_zh_Hans||(ALL&&m)
 	HIDDEN:=1
 	PKGARCH:=all


### PR DESCRIPTION
让翻译包从"能 select 拉起父 app"变成"只依附已选中的 app"

## Summary / 变更摘要

- `luci-app-clashoo/Makefile` 中 `luci-i18n-clashoo-zh-cn` 的 `DEPENDS:=+luci-app-clashoo` 去掉 `+`，改为硬依赖 `DEPENDS:=luci-app-clashoo`。
- 该翻译包原带 `DEFAULT:=LUCI_LANG_zh_Hans||(ALL&&m)`，带 `+` 等价于 `select` 父包，导致选中文界面即把 `luci-app-clashoo` 及其依赖 `clashoo` 一并拉起；去掉 `+` 后翻译包只依附于已显式选中的 app，不再反向拉起。

## Related Issues / 关联 Issue

Refs # （暂无）

## Validation / 验证

- 干净 `.config` 仅选 `luci` + `CONFIG_LUCI_LANG_zh_Hans=y`、不选任何 clashoo，`make defconfig` 后 `clashoo` / `luci-app-clashoo` / `luci-i18n-clashoo-zh-cn` 三项均为 `is not set`（修复前为 `=y`）。
- 选 clashoo + 中文时翻译仍正常提供，行为不变。

## Notes / 备注

- 与官方 `feeds/luci/luci.mk`（i18n 子包 `DEPENDS:=$(PKG_NAME)`）写法对齐。
- `kenzok8/small-package` 内同名包为镜像，存在同样问题，可同步按此行改法修复。