### PR TITLE
fix: normalize ipk package version (. -> ~) before comparison

### DIFF
--- a/clashoo/files/usr/share/clashoo/update/component_update.sh
+++ b/clashoo/files/usr/share/clashoo/update/component_update.sh
@@ -301,9 +301,10 @@ package_version_from_url() {
   case "$file" in
     clashoo_*_"$ARCH".ipk)
       v="${file#clashoo_}"
-      printf '%s\n' "${v%_${ARCH}.ipk}"
+      v="${v%_${ARCH}.ipk}"
+      printf '%s\n' "$v" | sed 's/^\([0-9][0-9][0-9][0-9]\.[0-9][0-9]*\.[0-9][0-9]*\)\./\1~/'
       ;;
-    clashoo_*.ipk) printf '%s\n' "$file" | sed -n 's/^clashoo_\(.*\)_[^_][^_]*\.ipk$/\1/p' ;;
+    clashoo_*.ipk) printf '%s\n' "$file" | sed -n 's/^clashoo_\(.*\)_[^_][^_]*\.ipk$/\1/p' | sed 's/^\([0-9][0-9][0-9][0-9]\.[0-9][0-9]*\.[0-9][0-9]*\)\./\1~/' ;;
     luci-app-clashoo_*.ipk) printf '%s\n' "$file" | sed -n 's/^luci-app-clashoo_\(.*\)_all\.ipk$/\1/p' ;;
     luci-i18n-clashoo-zh-cn_*.ipk) printf '%s\n' "$file" | sed -n 's/^luci-i18n-clashoo-zh-cn_\(.*\)_all\.ipk$/\1/p' ;;
     clashoo-*.apk)


### PR DESCRIPTION
The opkg-installed version uses '~' as separator (e.g. 2026.09.10~4aa9cc1-r2) while GitHub release asset filenames use '.' (e.g. clashoo_2026.09.10.4aa9cc1-r2_arch.ipk). The version string parsed from the URL in `package_version_from_url` therefore did not match the installed version, causing the post-install validation to fail and roll back the update.

The apk branch already normalizes `YYYY.MM.DD.` to `YYYY.MM.DD~`; apply the same normalization to both ipk branches.

Verified on ImmortalWrt 24.10 (opkg):
- parsed (before): 2026.09.10.4aa9cc1-r2
- installed:      2026.09.10~4aa9cc1-r2  -> mismatch
- parsed (after):  2026.09.10~4aa9cc1-r2  -> match

## Summary / 变更摘要

- 修复 package_version_from_url() 中 ipk 分支缺少版本号归一化，导致 opkg 系统上安装后校验失败、触发回滚
- 给 clashoo_*_"$ARCH".ipk 和 clashoo_*.ipk 两个分支加上与 apk 分支相同的 . → ~ 归一化

## Validation / 验证

ImmortalWrt 24.10.6（opkg，aarch64_cortex-a53）端到端测试，先降级到 2026.09.08~d5f57a5-r1，再通过 LuCI 面板更新。

修复前：
2026-09-11 12:26:16 - 目标版本：Clashoo 核心 2026.09.10.4aa9cc1-r2
2026-09-11 12:26:36 - 安装校验失败，正在恢复配置备份
2026-09-11 12:26:36 - 组件安装校验失败，已停止操作

修复后（同一降级包，只替换脚本）：
2026-09-11 12:59:47 - 目标版本：Clashoo 核心 2026.09.10~4aa9cc1-r2
2026-09-11 13:00:13 - 组件更新完成

## Notes / 备注

GitHub release 资产文件名把 ~ 写成 .，但 opkg 包内 control 元数据的 Version 仍是 ~。apk 分支已有归一化，ipk 分支漏了，所以只在 opkg 系统上触发。luci 包版本号无此问题，未改动。
-

